### PR TITLE
Remove __replica__ tag from samples

### DIFF
--- a/internal/otel/config/helpers/processors/resource_processor.go
+++ b/internal/otel/config/helpers/processors/resource_processor.go
@@ -19,9 +19,7 @@ type action string
 const (
 	upsertAction action = "upsert"
 
-	// clusterKey is the label key for "cluster" section of the Cortex High Availability client labels: https
-	// ://cortexmetrics.io/docs/guides/ha-pair-handling/#client-side. The __replica__ label is added at the receiver
-	// side for envoy metrics. If we cannot add __replica__ at the receiver we will need to add it here in the future.
+	// clusterKey is the label key for "cluster" which is specific to this resource.
 	clusterKey = "cluster"
 )
 

--- a/receivers/envoyreceiver/metrics/envoy.go
+++ b/receivers/envoyreceiver/metrics/envoy.go
@@ -63,7 +63,6 @@ func (r *Receiver) StreamMetrics(stream metricsv3.MetricsService_StreamMetricsSe
 			labels = map[string]string{
 				"envoy.cluster": identifier.GetNode().GetCluster(), // envoy.cluster is the service name in Consul
 				"node.id":       identifier.GetNode().GetId(),      // node.id delineate proxies
-				"__replica__":   identifier.GetNode().GetId(),      // __replica__ is used for Cortex HA metrics (deduplication)
 			}
 
 			fields := identifier.GetNode().GetMetadata().AsMap()


### PR DESCRIPTION

> In Cortex we make sure we only ingest from one of T1.a and T1.b, and only from one of T2.a and T2.b. We do this by electing a leader replica for each cluster of Prometheus. For example, in the case of T1, let it be T1.a. As long as T1.a is the leader, we drop the samples sent by T1.b. And if Cortex sees no new samples from T1.a for a short period (30s by default), it’ll switch the leader to be T1.b.

docs: https://cortexmetrics.io/docs/guides/ha-pair-handling/

Having `__replica__` will prevent ingestion of metrics from multiple proxies because one will be elected leader. It's not deduplication of metrics from a single replica, it's deduplication of samples across _all_ replicas