### PR TITLE
Add a test w/ a metric label w/ period

### DIFF
--- a/receivers/envoyreceiver/metrics/testdata/golden.json
+++ b/receivers/envoyreceiver/metrics/testdata/golden.json
@@ -143,6 +143,31 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "cluster_ef15b5b5_consul_telemetry_collector_default_otlp_single_node_cluster_internal_d1779413_9e75_e538_94cc_8a6b0e6a5175_consul_upstream_cx_total",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "envoy_cluster_name",
+                        "value": {
+                          "stringValue": "metrics_cluster"
+                        }
+                      },
+                      {
+                        "key": "consul.destination.partition",
+                        "value": {
+                          "stringValue": "default"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1682099630856000000",
+                    "asDouble": 1
+                  }
+                ]
+              }
             }
           ]
         }

--- a/receivers/envoyreceiver/metrics/testdata/source.json
+++ b/receivers/envoyreceiver/metrics/testdata/source.json
@@ -106,14 +106,36 @@
         "timestamp_ms": 1682099630190
       }
     ]
-   },
-   {
+  },
+  {
     "name": "server_stats_recent_lookups",
     "type": 1,
     "metric": [
       {
         "gauge": {
           "value": 2541
+        },
+        "timestamp_ms": 1682099630190
+      }
+    ]
+  },
+  {
+    "name": "cluster_ef15b5b5_consul_telemetry_collector_default_otlp_single_node_cluster_internal_d1779413_9e75_e538_94cc_8a6b0e6a5175_consul_upstream_cx_total",
+    "type": 1,
+    "metric": [
+      {
+        "label": [
+          {
+            "name": "envoy_cluster_name",
+            "value": "metrics_cluster"
+          },
+          {
+            "name": "consul.destination.partition",
+            "value": "default"
+          }
+        ],
+        "gauge": {
+          "value": 1
         },
         "timestamp_ms": 1682099630190
       }


### PR DESCRIPTION
>  we’re not handling the naming quite right somewhere along the metrics ingestion pipeline. We’re only keeping the suffix of each. Eg only`namespace` gets into backend, not “consul_source_namespace” or “consul_destination_namespace” which is… unfortunate.

Actual fix may be in a Consul patch, but this adds to the existing `ExportMetrics` test to validate that we're keeping label names when they have periods