### PR TITLE
Add missing cloud stanza fields to Cloud validation err

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"go.uber.org/multierr"
 
@@ -16,7 +17,7 @@ import (
 
 var (
 	errNoConfigurationProvided = errors.New("no configuration provided: see usage")
-	errCloudConfigInvalid      = fmt.Errorf("cloud configuration is not valid")
+	errCloudConfigInvalid      = errors.New("cloud configuration is not valid")
 )
 
 func configFromEnvVars() *Config {
@@ -88,19 +89,39 @@ func (c *Cloud) IsEnabled() bool {
 	if c == nil {
 		return false
 	}
+
 	if c.ClientSecret != "" || c.ClientID != "" || c.ResourceID != "" {
 		return true
 	}
+
 	return false
 }
 
+// validate that, if the Cloud config is enabled, all required fields are set.
+// Return an error describing missing fields.
 func (c *Cloud) validate() error {
 	if c == nil {
 		return nil
 	}
-	if c.IsEnabled() && (c.ClientID == "" || c.ClientSecret == "" || c.ResourceID == "") {
-		return errCloudConfigInvalid
+
+	if !c.IsEnabled() {
+		return nil
 	}
+
+	msg := []string{}
+	if c.ClientID == "" {
+		msg = append(msg, "client_id")
+	}
+	if c.ClientSecret == "" {
+		msg = append(msg, "client_secret")
+	}
+	if c.ResourceID == "" {
+		msg = append(msg, "resource_id")
+	}
+	if len(msg) > 0 {
+		return fmt.Errorf("%w: missing %s", errCloudConfigInvalid, strings.Join(msg, ", "))
+	}
+
 	return nil
 }
 

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -108,18 +108,18 @@ func (c *Cloud) validate() error {
 		return nil
 	}
 
-	msg := []string{}
+	missing := []string{}
 	if c.ClientID == "" {
-		msg = append(msg, "client_id")
+		missing = append(missing, "client_id")
 	}
 	if c.ClientSecret == "" {
-		msg = append(msg, "client_secret")
+		missing = append(missing, "client_secret")
 	}
 	if c.ResourceID == "" {
-		msg = append(msg, "resource_id")
+		missing = append(missing, "resource_id")
 	}
-	if len(msg) > 0 {
-		return fmt.Errorf("%w: missing %s", errCloudConfigInvalid, strings.Join(msg, ", "))
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: missing %s", errCloudConfigInvalid, strings.Join(missing, ", "))
 	}
 
 	return nil

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -14,9 +14,11 @@ import (
 
 func Test_Validation(t *testing.T) {
 	endpoint, cid, csec, crid := "endpoint", "cid", "csec", "crid"
+
 	for name, tc := range map[string]struct {
-		input *Config
-		err   error
+		input       *Config
+		err         error
+		errContains string
 	}{
 		"FailNoConfig": {
 			err: errNoConfigurationProvided,
@@ -43,7 +45,8 @@ func Test_Validation(t *testing.T) {
 					ResourceID: crid,
 				},
 			},
-			err: errCloudConfigInvalid,
+			err:         errCloudConfigInvalid,
+			errContains: "missing client_id, client_secret",
 		},
 		"FailCloudResourceMissingClientID": {
 			input: &Config{
@@ -52,7 +55,8 @@ func Test_Validation(t *testing.T) {
 					ResourceID:   crid,
 				},
 			},
-			err: errCloudConfigInvalid,
+			err:         errCloudConfigInvalid,
+			errContains: "missing client_id",
 		},
 		"FailCloudResourceMissingResourceID": {
 			input: &Config{
@@ -61,7 +65,8 @@ func Test_Validation(t *testing.T) {
 					ClientID:     cid,
 				},
 			},
-			err: errCloudConfigInvalid,
+			err:         errCloudConfigInvalid,
+			errContains: "missing resource_id",
 		},
 		"FailCloudResourceMissingClientSecret": {
 			input: &Config{
@@ -89,6 +94,7 @@ func Test_Validation(t *testing.T) {
 			if tc.err != nil {
 				test.Error(t, err)
 				test.ErrorIs(t, err, tc.err)
+				test.ErrorContains(t, err, tc.errContains)
 				return
 			}
 			test.NoError(t, err)


### PR DESCRIPTION
This adds checks for each of client_id, client_secret, and resource_id and includes those missing fields in the error returned during Cloud config validation.

### Testing

update unit tests