### PR TITLE
Modifying spike limit

### DIFF
--- a/internal/otel/config/helpers/processors/memorylimiter_processor.go
+++ b/internal/otel/config/helpers/processors/memorylimiter_processor.go
@@ -20,6 +20,6 @@ func MemoryLimiterCfg() *memorylimiterprocessor.Config {
 	return &memorylimiterprocessor.Config{
 		CheckInterval:         time.Second,
 		MemoryLimitPercentage: 80,
-		MemorySpikePercentage: 75,
+		MemorySpikePercentage: 20,
 	}
 }

--- a/internal/otel/testdata/hcp-with-forwarder.yaml
+++ b/internal/otel/testdata/hcp-with-forwarder.yaml
@@ -17,7 +17,7 @@ processors:
   memory_limiter:
     check_interval: 1s
     limit_percentage: 80
-    spike_limit_percentage: 75
+    spike_limit_percentage: 20
   batch:
   filter:
     metrics:

--- a/internal/otel/testdata/hcp.yaml
+++ b/internal/otel/testdata/hcp.yaml
@@ -17,7 +17,7 @@ processors:
   memory_limiter:
     check_interval: 1s
     limit_percentage: 80
-    spike_limit_percentage: 75
+    spike_limit_percentage: 20
   batch:
   filter:
     metrics:

--- a/internal/otel/testdata/stock-with-forwarder.yaml
+++ b/internal/otel/testdata/stock-with-forwarder.yaml
@@ -17,7 +17,7 @@ processors:
   memory_limiter:
     check_interval: 1s
     limit_percentage: 80
-    spike_limit_percentage: 75
+    spike_limit_percentage: 20
   batch:
 
 extensions:

--- a/internal/otel/testdata/stock.yaml
+++ b/internal/otel/testdata/stock.yaml
@@ -17,7 +17,7 @@ processors:
   memory_limiter:
     check_interval: 1s
     limit_percentage: 80
-    spike_limit_percentage: 75
+    spike_limit_percentage: 20
   batch:
 
 extensions:


### PR DESCRIPTION
The calculation for spike limit is the total limit - the spike limit so 85-75 results in a spread of 10% which is very small. Instead we want a larger spread so 85-20 gives us a 65% spread which provides higher spike amounts. Interestingly a spike limit percentage of a higher amount results in a lower actual  allowed spike. 