### PR TITLE
Setting batch processor limits

### DIFF
--- a/internal/otel/config/helpers/processors/batch_processor.go
+++ b/internal/otel/config/helpers/processors/batch_processor.go
@@ -4,6 +4,8 @@
 package processors
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
 )
@@ -17,6 +19,8 @@ var BatchProcessorID component.ID = component.NewID(batchProcessorName)
 func BatchProcessorCfg() *batchprocessor.Config {
 	factory := batchprocessor.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*batchprocessor.Config)
+	cfg.SendBatchSize = 8192
+	cfg.Timeout = time.Minute * 1
 
 	return cfg
 }

--- a/internal/otel/testdata/hcp-with-forwarder.yaml
+++ b/internal/otel/testdata/hcp-with-forwarder.yaml
@@ -19,6 +19,7 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 20
   batch:
+    timeout: 1m
   filter:
     metrics:
       include:

--- a/internal/otel/testdata/hcp.yaml
+++ b/internal/otel/testdata/hcp.yaml
@@ -19,6 +19,7 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 20
   batch:
+    timeout: 1m
   filter:
     metrics:
       include:

--- a/internal/otel/testdata/stock-with-forwarder.yaml
+++ b/internal/otel/testdata/stock-with-forwarder.yaml
@@ -19,6 +19,7 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 20
   batch:
+    timeout: 1m
 
 extensions:
   memory_ballast:

--- a/internal/otel/testdata/stock.yaml
+++ b/internal/otel/testdata/stock.yaml
@@ -19,6 +19,7 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 20
   batch:
+    timeout: 1m
 
 extensions:
   memory_ballast:


### PR DESCRIPTION
Currently as soon as metrics come in we are sending them off right away. This is resulting in a lot of load hitting the ctgw and forcing the CPU up. Both the consul server and the services should be going out with 1 minute each. 