### PR TITLE
Create more otlphttp configuration options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/runtime v0.25.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/consul-telemetry-collector/receivers/envoyreceiver v0.0.0-20230907200253-024ee4b37903
 	github.com/hashicorp/go-hclog v1.5.0
@@ -27,9 +28,9 @@ require (
 	go.opentelemetry.io/collector/component v0.85.0
 	go.opentelemetry.io/collector/config/configauth v0.84.0
 	go.opentelemetry.io/collector/config/configgrpc v0.84.0
+	go.opentelemetry.io/collector/config/confighttp v0.84.0
 	go.opentelemetry.io/collector/config/configopaque v0.84.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.85.0
-	go.opentelemetry.io/collector/config/configtls v0.84.0
 	go.opentelemetry.io/collector/confmap v0.85.0
 	go.opentelemetry.io/collector/exporter v0.85.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.72.0
@@ -114,7 +115,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
@@ -207,8 +207,8 @@ require (
 	go.mongodb.org/mongo-driver v1.11.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v0.84.0 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.84.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.85.0 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.84.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.84.0 // indirect
 	go.opentelemetry.io/collector/connector v0.85.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.85.0 // indirect

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -139,6 +139,8 @@ func (c *Command) Run(args []string) int {
 		return -1
 	}
 
+	cfg.logDeprecations(logger)
+
 	service, err := NewService(cfg)
 	if err != nil {
 		logger.Error("error creating service", "error", err)

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -84,7 +84,7 @@ type Cloud struct {
 	ResourceID   string `hcl:"resource_id,optional"`
 }
 
-// ExporterConfig holds
+// ExporterConfig holds configuration options to export metrics to a desired custom endpoint.
 type ExporterConfig struct {
 	Type     string            `hcl:"type,label"`
 	Headers  map[string]string `hcl:"headers,optional"`

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -167,7 +167,12 @@ func (c *Config) validate() error {
 
 func (c *Config) logDeprecations(logger hclog.Logger) {
 	const deprecatedWarning = "'%s' is deprecated and will be removed in a future release. Use '%s' instead."
+	const conflictingConfig = "deprecated field '%s' and supported config '%s' are both configured. Using '%s'"
 	if c.HTTPCollectorEndpoint != "" {
 		logger.Warn(deprecatedWarning, "http_collector_endpoint", "exporter_config")
+	}
+
+	if c.ExporterConfig != nil && c.HTTPCollectorEndpoint != "" {
+		logger.Warn(conflictingConfig, "http_collector_endpoint", "exporter_config", "exporter_config")
 	}
 }

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	"go.uber.org/multierr"
 
@@ -67,24 +66,7 @@ func readConfiguration(reader io.Reader, filename string) (*Config, error) {
 		return nil, fmt.Errorf("failed parsing config file: %w", err)
 	}
 
-	if err = parseExportConfig(cfg); err != nil {
-		return nil, fmt.Errorf("failed parsing config file: %w", err)
-	}
-
 	return cfg, nil
-}
-
-func parseExportConfig(c *Config) error {
-	if c.ExporterConfig != nil {
-		if c.ExporterConfig.Timeout != "" {
-			d, err := time.ParseDuration(c.ExporterConfig.Timeout)
-			if err != nil {
-				return fmt.Errorf("failed to parse export config. unable to parse timeout %s %w", c.ExporterConfig.Timeout, err)
-			}
-			c.ExporterConfig.timeoutDuration = d
-		}
-	}
-	return nil
 }
 
 // Config is the global collector configuration.
@@ -104,11 +86,10 @@ type Cloud struct {
 
 // ExporterConfig holds
 type ExporterConfig struct {
-	Type            string            `hcl:"type,label"`
-	Headers         map[string]string `hcl:"headers,optional"`
-	Endpoint        string            `hcl:"endpoint"`
-	Timeout         string            `hcl:"timeout,optional"`
-	timeoutDuration time.Duration
+	Type     string            `hcl:"type,label"`
+	Headers  map[string]string `hcl:"headers,optional"`
+	Endpoint string            `hcl:"endpoint"`
+	Timeout  string            `hcl:"timeout,optional"`
 }
 
 // IsEnabled checks if the Cloud config is enabled. It returns false if the ClientID,

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -215,15 +215,29 @@ func Test_ReadFile(t *testing.T) {
 				"client_id": "%s",
 				"client_secret": "%s"
 			},
-			"http_collector_endpoint": "%s"
+			"http_collector_endpoint": "%s",
+			"exporter_config": {
+				"otelhttp": {
+					"endpoint": "%s",
+					"headers": {
+						"a": "b"
+					},
+					"timeout": "10s"
+				}
 			}
-			`, clientid, clientsecret, endpoint),
+			}`, clientid, clientsecret, endpoint, endpoint),
 			expect: &Config{
 				Cloud: &Cloud{
 					ClientID:     clientid,
 					ClientSecret: clientsecret,
 				},
 				HTTPCollectorEndpoint: endpoint,
+				ExporterConfig: &ExporterConfig{
+					Type:     "otelhttp",
+					Endpoint: endpoint,
+					Headers:  map[string]string{"a": "b"},
+					Timeout:  "10s",
+				},
 			},
 		},
 		"AllFields": {

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/shoenig/test"
@@ -200,10 +199,9 @@ func Test_ReadFile(t *testing.T) {
 			`,
 			expect: &Config{
 				ExporterConfig: &ExporterConfig{
-					Type:            "otelgrpc",
-					Endpoint:        "http://otel:3749",
-					timeoutDuration: time.Second * 10,
-					Timeout:         "10s",
+					Type:     "otelgrpc",
+					Endpoint: "http://otel:3749",
+					Timeout:  "10s",
 					Headers: map[string]string{
 						"a": "b",
 					},
@@ -284,7 +282,6 @@ func Test_ReadFile(t *testing.T) {
 			diff := cmp.Diff(outputConfig, tc.expect, cmp.AllowUnexported(ExporterConfig{}))
 			test.NoError(t, err)
 			test.Eq(t, outputConfig, tc.expect, test.Sprint(diff))
-
 		})
 	}
 }

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel"
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/go-hclog"
+
+	"go.opentelemetry.io/collector/component"
 )
 
 // Service runs a otel.Collector with a configured otel pipeline.
@@ -26,9 +29,9 @@ func NewService(cfg *Config) (*Service, error) {
 	s := &Service{}
 
 	if cfg.HTTPCollectorEndpoint != "" {
-		s.cfg.ExporterConfig = &otel.OTLPExporterConfig{
-			Type: exporters.BaseOtlpExporterID.Name(),
-			ExporterConfig: exporters.ExporterConfig{
+		s.cfg.ExporterConfig = &config.ExportConfig{
+			ID: exporters.BaseOtlpExporterID,
+			Exporter: &exporters.ExporterConfig{
 				Endpoint: cfg.HTTPCollectorEndpoint,
 			},
 		}
@@ -50,9 +53,9 @@ func NewService(cfg *Config) (*Service, error) {
 	}
 
 	if cfg.ExporterConfig != nil {
-		s.cfg.ExporterConfig = &otel.OTLPExporterConfig{
-			Type: cfg.ExporterConfig.Type,
-			ExporterConfig: exporters.ExporterConfig{
+		s.cfg.ExporterConfig = &config.ExportConfig{
+			ID: component.NewID(component.Type(cfg.ExporterConfig.Type)),
+			Exporter: &exporters.ExporterConfig{
 				Headers:  cfg.ExporterConfig.Headers,
 				Endpoint: cfg.ExporterConfig.Endpoint,
 				// Timeout:  cfg.ExporterConfig.timeoutDuration,

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel"
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -25,9 +26,11 @@ func NewService(cfg *Config) (*Service, error) {
 	s := &Service{}
 
 	if cfg.HTTPCollectorEndpoint != "" {
-		s.cfg.ExporterConfig = &otel.ExporterConfig{
-			Type:     "otlphttp",
-			Endpoint: cfg.HTTPCollectorEndpoint,
+		s.cfg.ExporterConfig = &otel.OTLPExporterConfig{
+			Type: exporters.BaseOtlpExporterID.Name(),
+			ExporterConfig: exporters.ExporterConfig{
+				Endpoint: cfg.HTTPCollectorEndpoint,
+			},
 		}
 	}
 
@@ -47,11 +50,13 @@ func NewService(cfg *Config) (*Service, error) {
 	}
 
 	if cfg.ExporterConfig != nil {
-		s.cfg.ExporterConfig = &otel.ExporterConfig{
-			Type:     cfg.ExporterConfig.Type,
-			Headers:  cfg.ExporterConfig.Headers,
-			Endpoint: cfg.ExporterConfig.Endpoint,
-			Timeout:  cfg.ExporterConfig.timeoutDuration,
+		s.cfg.ExporterConfig = &otel.OTLPExporterConfig{
+			Type: cfg.ExporterConfig.Type,
+			ExporterConfig: exporters.ExporterConfig{
+				Headers:  cfg.ExporterConfig.Headers,
+				Endpoint: cfg.ExporterConfig.Endpoint,
+				// Timeout:  cfg.ExporterConfig.timeoutDuration,
+			},
 		}
 	}
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -29,7 +29,7 @@ func NewService(cfg *Config) (*Service, error) {
 	s := &Service{}
 
 	if cfg.HTTPCollectorEndpoint != "" {
-		s.cfg.ExporterConfig = &config.ExportConfig{
+		s.cfg.ExporterConfig = &config.ExporterConfig{
 			ID: exporters.BaseOtlpExporterID,
 			Exporter: &exporters.ExporterConfig{
 				Endpoint: cfg.HTTPCollectorEndpoint,
@@ -53,7 +53,7 @@ func NewService(cfg *Config) (*Service, error) {
 	}
 
 	if cfg.ExporterConfig != nil {
-		s.cfg.ExporterConfig = &config.ExportConfig{
+		s.cfg.ExporterConfig = &config.ExporterConfig{
 			ID: component.NewID(component.Type(cfg.ExporterConfig.Type)),
 			Exporter: &exporters.ExporterConfig{
 				Headers:  cfg.ExporterConfig.Headers,

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -9,13 +9,13 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
+
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/go-hclog"
-
-	"go.opentelemetry.io/collector/component"
 )
 
 // Service runs a otel.Collector with a configured otel pipeline.
@@ -58,7 +58,7 @@ func NewService(cfg *Config) (*Service, error) {
 			Exporter: &exporters.ExporterConfig{
 				Headers:  cfg.ExporterConfig.Headers,
 				Endpoint: cfg.ExporterConfig.Endpoint,
-				// Timeout:  cfg.ExporterConfig.timeoutDuration,
+				Timeout:  cfg.ExporterConfig.Timeout,
 			},
 		}
 	}

--- a/internal/otel/collector.go
+++ b/internal/otel/collector.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
-	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
 )
 
@@ -31,13 +30,7 @@ type CollectorCfg struct {
 	ResourceID        string
 	Client            hcp.TelemetryClient
 	ForwarderEndpoint string
-	ExporterConfig    *config.ExportConfig
-}
-
-// OTLPExporterConfig holds the type and
-type OTLPExporterConfig struct {
-	ExporterConfig exporters.ExporterConfig
-	Type           string
+	ExporterConfig    *config.ExporterConfig
 }
 
 const otelFeatureGate = "telemetry.useOtelForInternalMetrics"

--- a/internal/otel/collector.go
+++ b/internal/otel/collector.go
@@ -5,13 +5,13 @@ package otel
 
 import (
 	"context"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
 )
 
@@ -30,15 +30,13 @@ type CollectorCfg struct {
 	ResourceID        string
 	Client            hcp.TelemetryClient
 	ForwarderEndpoint string
-	ExporterConfig    *ExporterConfig
+	ExporterConfig    *OTLPExporterConfig
 }
 
-// ExporterConfig holds
-type ExporterConfig struct {
-	Type     string
-	Headers  map[string]string
-	Endpoint string
-	Timeout  time.Duration
+// OTLPExporterConfig holds the type and
+type OTLPExporterConfig struct {
+	ExporterConfig exporters.ExporterConfig
+	Type           string
 }
 
 const otelFeatureGate = "telemetry.useOtelForInternalMetrics"

--- a/internal/otel/collector.go
+++ b/internal/otel/collector.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
 )
@@ -30,7 +31,7 @@ type CollectorCfg struct {
 	ResourceID        string
 	Client            hcp.TelemetryClient
 	ForwarderEndpoint string
-	ExporterConfig    *OTLPExporterConfig
+	ExporterConfig    *config.ExportConfig
 }
 
 // OTLPExporterConfig holds the type and

--- a/internal/otel/collector.go
+++ b/internal/otel/collector.go
@@ -5,6 +5,7 @@ package otel
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
@@ -29,6 +30,15 @@ type CollectorCfg struct {
 	ResourceID        string
 	Client            hcp.TelemetryClient
 	ForwarderEndpoint string
+	ExporterConfig    *ExporterConfig
+}
+
+// ExporterConfig holds
+type ExporterConfig struct {
+	Type     string
+	Headers  map[string]string
+	Endpoint string
+	Timeout  time.Duration
 }
 
 const otelFeatureGate = "telemetry.useOtelForInternalMetrics"

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -6,11 +6,9 @@ package otel
 import (
 	"fmt"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/otelcol"
 
-	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/providers/external"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/providers/hcp"
 )
@@ -21,18 +19,10 @@ func newProvider(cfg CollectorCfg) (otelcol.ConfigProvider, error) {
 		uris = append(uris, fmt.Sprintf("hcp:%s", cfg.ResourceID))
 	}
 
-	var exportID component.ID
-	var exportConfig config.Exporter
-	// TODO: Make sure a nil ExporterConfig is tested
-	if cfg.ExporterConfig != nil {
-		exportID = cfg.ExporterConfig.ID
-		exportConfig = cfg.ExporterConfig.Exporter
-	}
-
 	resolver := confmap.ResolverSettings{
 		URIs: uris,
 		Providers: makeMapProvidersMap(
-			external.NewProvider(exportID, exportConfig),
+			external.NewProvider(cfg.ExporterConfig),
 			hcp.NewProvider(cfg.ExporterConfig, cfg.Client, cfg.ClientID, cfg.ClientSecret),
 		),
 		Converters: []confmap.Converter{},

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
-	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/providers/external"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/providers/hcp"
 )
@@ -23,22 +22,18 @@ func newProvider(cfg CollectorCfg) (otelcol.ConfigProvider, error) {
 	}
 
 	var exportID component.ID
-	var exportConfig *exporters.ExporterConfig
-	var exportCfg *config.ExportConfig
+	var exportConfig config.Exporter
+	// TODO: Make sure a nil ExporterConfig is tested
 	if cfg.ExporterConfig != nil {
-		exportID = component.NewID(component.Type(cfg.ExporterConfig.Type))
-		exportConfig = &cfg.ExporterConfig.ExporterConfig
-		exportCfg = &config.ExportConfig{
-			ID:       exportID,
-			Exporter: exportConfig,
-		}
+		exportID = cfg.ExporterConfig.ID
+		exportConfig = cfg.ExporterConfig.Exporter
 	}
 
 	resolver := confmap.ResolverSettings{
 		URIs: uris,
 		Providers: makeMapProvidersMap(
 			external.NewProvider(exportID, exportConfig),
-			hcp.NewProvider(exportCfg, cfg.Client, cfg.ClientID, cfg.ClientSecret),
+			hcp.NewProvider(cfg.ExporterConfig, cfg.Client, cfg.ClientID, cfg.ClientSecret),
 		),
 		Converters: []confmap.Converter{},
 	}

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -6,6 +6,7 @@ package otel
 import (
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/otelcol"
 
@@ -18,13 +19,15 @@ func newProvider(cfg CollectorCfg) (otelcol.ConfigProvider, error) {
 	if cfg.ResourceID != "" {
 		uris = append(uris, fmt.Sprintf("hcp:%s", cfg.ResourceID))
 	}
+
+	exportID := component.NewID(component.Type(cfg.ExporterConfig.Type))
+
 	resolver := confmap.ResolverSettings{
 		URIs: uris,
 		Providers: makeMapProvidersMap(
-			external.NewProvider(cfg.ForwarderEndpoint),
+			external.NewProvider(exportID, &cfg.ExporterConfig.ExporterConfig),
 			hcp.NewProvider(cfg.ForwarderEndpoint, cfg.Client, cfg.ClientID, cfg.ClientSecret),
 		),
-
 		Converters: []confmap.Converter{},
 	}
 

--- a/internal/otel/config/builder.go
+++ b/internal/otel/config/builder.go
@@ -19,7 +19,7 @@ import (
 // these inputs.
 type Params struct {
 	OtlpHTTPEndpoint string
-	ExporterConfig   *ExporterConfig
+	ExporterConfig   *ExportConfig
 	Client           hcp.TelemetryClient
 	ClientID         string
 	ClientSecret     string
@@ -27,8 +27,8 @@ type Params struct {
 }
 
 type ExportConfig struct {
-	id       component.ID
-	exporter Exporter
+	ID       component.ID
+	Exporter Exporter
 }
 type Exporter interface {
 	Config() (*confmap.Conf, error)
@@ -53,6 +53,8 @@ func PipelineConfigBuilder(p *Params) pipelines.PipelineConfig {
 		baseCfg.Exporters = append(baseCfg.Exporters, exporters.HCPExporterID)
 	} else if p.OtlpHTTPEndpoint != "" {
 		baseCfg.Exporters = append(baseCfg.Exporters, exporters.BaseOtlpExporterID)
+	} else if p.ExporterConfig != nil {
+		baseCfg.Exporters = append(baseCfg.Exporters, p.ExporterConfig.ID)
 	}
 
 	return baseCfg

--- a/internal/otel/config/builder.go
+++ b/internal/otel/config/builder.go
@@ -18,12 +18,11 @@ import (
 // Params are the inputs to the configuration building process. Only some config requires
 // these inputs.
 type Params struct {
-	OtlpHTTPEndpoint string
-	ExporterConfig   *ExportConfig
-	Client           hcp.TelemetryClient
-	ClientID         string
-	ClientSecret     string
-	ResourceID       string
+	ExporterConfig *ExportConfig
+	Client         hcp.TelemetryClient
+	ClientID       string
+	ClientSecret   string
+	ResourceID     string
 }
 
 type ExportConfig struct {
@@ -51,8 +50,6 @@ func PipelineConfigBuilder(p *Params) pipelines.PipelineConfig {
 	includeHCPPipeline := p.ClientID != "" && p.ClientSecret != "" && p.Client != nil
 	if includeHCPPipeline {
 		baseCfg.Exporters = append(baseCfg.Exporters, exporters.HCPExporterID)
-	} else if p.OtlpHTTPEndpoint != "" {
-		baseCfg.Exporters = append(baseCfg.Exporters, exporters.BaseOtlpExporterID)
 	} else if p.ExporterConfig != nil {
 		baseCfg.Exporters = append(baseCfg.Exporters, p.ExporterConfig.ID)
 	}

--- a/internal/otel/config/builder.go
+++ b/internal/otel/config/builder.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service/pipelines"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
@@ -18,10 +19,19 @@ import (
 // these inputs.
 type Params struct {
 	OtlpHTTPEndpoint string
+	ExporterConfig   *ExporterConfig
 	Client           hcp.TelemetryClient
 	ClientID         string
 	ClientSecret     string
 	ResourceID       string
+}
+
+type ExportConfig struct {
+	id       component.ID
+	exporter Exporter
+}
+type Exporter interface {
+	Config() (*confmap.Conf, error)
 }
 
 // PipelineConfigBuilder defines a basic list of pipeline component IDs for a service.PipelineConfig.

--- a/internal/otel/config/builder.go
+++ b/internal/otel/config/builder.go
@@ -25,10 +25,13 @@ type Params struct {
 	ResourceID     string
 }
 
+// ExportConfig holds a dynamic exporter configuration and corresponding component.ID
 type ExportConfig struct {
 	ID       component.ID
 	Exporter Exporter
 }
+
+// Exporter returns the confmap.Conf representation of an open-telemetry-collector exporter
 type Exporter interface {
 	Config() (*confmap.Conf, error)
 }

--- a/internal/otel/config/builder.go
+++ b/internal/otel/config/builder.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service/pipelines"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
@@ -18,22 +17,17 @@ import (
 // Params are the inputs to the configuration building process. Only some config requires
 // these inputs.
 type Params struct {
-	ExporterConfig *ExportConfig
+	ExporterConfig *ExporterConfig
 	Client         hcp.TelemetryClient
 	ClientID       string
 	ClientSecret   string
 	ResourceID     string
 }
 
-// ExportConfig holds a dynamic exporter configuration and corresponding component.ID
-type ExportConfig struct {
+// ExporterConfig holds a dynamic exporter configuration and corresponding component.ID
+type ExporterConfig struct {
 	ID       component.ID
-	Exporter Exporter
-}
-
-// Exporter returns the confmap.Conf representation of an open-telemetry-collector exporter
-type Exporter interface {
-	Config() (*confmap.Conf, error)
+	Exporter *exporters.ExporterConfig
 }
 
 // PipelineConfigBuilder defines a basic list of pipeline component IDs for a service.PipelineConfig.

--- a/internal/otel/config/config.go
+++ b/internal/otel/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service"
@@ -31,6 +32,14 @@ type Config struct {
 	Connectors componentMap   `mapstructure:"connectors"`
 	Extensions componentMap   `mapstructure:"extensions"`
 	Service    service.Config `mapstructure:"service"`
+}
+
+// ExporterConfig holds
+type ExporterConfig struct {
+	Type     string
+	Headers  map[string]string
+	Endpoint string
+	Timeout  time.Duration
 }
 
 // NewConfig creates a new config object with all types initialized.

--- a/internal/otel/config/config.go
+++ b/internal/otel/config/config.go
@@ -150,7 +150,7 @@ func buildComponent(id component.ID, p *Params) (any, error) {
 		return extensions.OauthClientCfg(p.ClientID, p.ClientSecret), nil
 	default:
 		if id == p.ExporterConfig.ID {
-			cfg, err := p.ExporterConfig.Exporter.Config()
+			cfg, err := exporters.OtlpExporterCfg(p.ExporterConfig.Exporter)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/otel/config/helpers/exporters/otlp_exporter.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter.go
@@ -56,7 +56,7 @@ type ExporterConfig struct {
 	Compression string `mapstructure:"compression"`
 
 	// Timeout is the http request time limit
-	Timeout string `mapstructure:"timeout"`
+	Timeout string `mapstructure:"timeout,omitempty"`
 }
 
 // Config implemented the config.Exporter interface to return the current configuration as a confmap.Conf allowing external configuration of this exporter

--- a/internal/otel/config/helpers/exporters/otlp_exporter.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter.go
@@ -9,6 +9,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configauth"
+	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/types"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
@@ -52,6 +53,14 @@ type ExporterConfig struct {
 
 	// The compression key for supported compression types within collector.
 	Compression string `mapstructure:"compression"`
+}
+
+func (e *ExporterConfig) Config() (*confmap.Conf, error) {
+	c := confmap.New()
+	if err := c.Marshal(&e); err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 // OtlpExporterCfg generates the configuration for a otlp exporter.

--- a/internal/otel/config/helpers/exporters/otlp_exporter.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/types"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
+	"github.com/imdario/mergo"
 )
 
 const (
@@ -56,6 +57,10 @@ type ExporterConfig struct {
 }
 
 func (e *ExporterConfig) Config() (*confmap.Conf, error) {
+	defaultConfig := OtlpExporterCfg(e.Endpoint)
+	if err := mergo.Merge(e, defaultConfig); err != nil {
+		return nil, err
+	}
 	c := confmap.New()
 	if err := c.Marshal(&e); err != nil {
 		return nil, err

--- a/internal/otel/config/helpers/exporters/otlp_exporter.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter.go
@@ -59,6 +59,7 @@ type ExporterConfig struct {
 	Timeout string `mapstructure:"timeout"`
 }
 
+// Config implemented the config.Exporter interface to return the current configuration as a confmap.Conf allowing external configuration of this exporter
 func (e *ExporterConfig) Config() (*confmap.Conf, error) {
 	defaultConfig := OtlpExporterCfg(e.Endpoint)
 	if err := mergo.Merge(e, defaultConfig); err != nil {

--- a/internal/otel/config/helpers/exporters/otlp_exporter.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/imdario/mergo"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/types"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
-	"github.com/imdario/mergo"
 )
 
 const (
@@ -54,6 +54,9 @@ type ExporterConfig struct {
 
 	// The compression key for supported compression types within collector.
 	Compression string `mapstructure:"compression"`
+
+	// Timeout is the http request time limit
+	Timeout string `mapstructure:"timeout"`
 }
 
 func (e *ExporterConfig) Config() (*confmap.Conf, error) {

--- a/internal/otel/config/helpers/exporters/otlp_exporter_test.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter_test.go
@@ -12,12 +12,10 @@ import (
 )
 
 func Test_OtlpExporter(t *testing.T) {
-	cfg := OtlpExporterCfg("foobar")
-	require.NotNil(t, cfg)
-
-	// Marshall the configuration
-	conf := confmap.New()
-	err := conf.Marshal(cfg)
+	e := &ExporterConfig{
+		Endpoint: "foobar",
+	}
+	conf, err := OtlpExporterCfg(e)
 	require.NoError(t, err)
 
 	// Unmarshall and verify
@@ -25,7 +23,9 @@ func Test_OtlpExporter(t *testing.T) {
 	err = conf.Unmarshal(unmarshalledCfg)
 	require.NoError(t, err)
 
-	require.Equal(t, cfg, unmarshalledCfg)
+	require.Equal(t, e.Endpoint, unmarshalledCfg.Endpoint)
+	require.Equal(t, e.Compression, defaultCompression)
+	require.Equal(t, unmarshalledCfg.Headers["user-agent"], defaultUserAgent)
 }
 
 func Test_OtlpExporterHCP(t *testing.T) {

--- a/internal/otel/config_test.go
+++ b/internal/otel/config_test.go
@@ -16,21 +16,27 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/hcp-sdk-go/resource"
 )
 
 func Test_newConfigProvider(t *testing.T) {
 	testcases := map[string]struct {
 		testfile    string
-		forwarder   string
+		exporter    *OTLPExporterConfig
 		hcpResource *resource.Resource
 	}{
 		"stock": {
 			testfile: "stock.yaml",
 		},
 		"stock-with-forwarder": {
-			testfile:  "stock-with-forwarder.yaml",
-			forwarder: "https://test-forwarder-endpoint:4138",
+			testfile: "stock-with-forwarder.yaml",
+			exporter: &OTLPExporterConfig{
+				Type: exporters.BaseOtlpExporterID.String(),
+				ExporterConfig: exporters.ExporterConfig{
+					Endpoint: "https://test-forwarder-endpoint:4138",
+				},
+			},
 		},
 		"hcp": {
 			testfile: "hcp.yaml",
@@ -42,13 +48,18 @@ func Test_newConfigProvider(t *testing.T) {
 			},
 		},
 		"hcp-with-forwarder": {
-			testfile:  "hcp-with-forwarder.yaml",
-			forwarder: "https://test-forwarder-endpoint:4138",
+			testfile: "hcp-with-forwarder.yaml",
 			hcpResource: &resource.Resource{
 				ID:           "otel-with-cluster",
 				Type:         "hashicorp.consul.cluster",
 				Organization: "00000000-0000-0000-0000-000000000003",
 				Project:      "00000000-0000-0000-0000-000000000004",
+			},
+			exporter: &OTLPExporterConfig{
+				Type: exporters.BaseOtlpExporterID.String(),
+				ExporterConfig: exporters.ExporterConfig{
+					Endpoint: "https://test-forwarder-endpoint:4138",
+				},
 			},
 		},
 	}
@@ -67,11 +78,11 @@ func Test_newConfigProvider(t *testing.T) {
 				}
 			}
 			c := CollectorCfg{
-				ClientID:          "cid",
-				ClientSecret:      "csec",
-				Client:            mockClient,
-				ResourceID:        resourceURL,
-				ForwarderEndpoint: tc.forwarder,
+				ClientID:       "cid",
+				ClientSecret:   "csec",
+				Client:         mockClient,
+				ResourceID:     resourceURL,
+				ExporterConfig: tc.exporter,
 			}
 			provider, err := newProvider(c)
 			test.NoError(t, err)

--- a/internal/otel/config_test.go
+++ b/internal/otel/config_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/hcp-sdk-go/resource"
 )
@@ -23,7 +24,7 @@ import (
 func Test_newConfigProvider(t *testing.T) {
 	testcases := map[string]struct {
 		testfile    string
-		exporter    *OTLPExporterConfig
+		exporter    *config.ExportConfig
 		hcpResource *resource.Resource
 	}{
 		"stock": {
@@ -31,9 +32,9 @@ func Test_newConfigProvider(t *testing.T) {
 		},
 		"stock-with-forwarder": {
 			testfile: "stock-with-forwarder.yaml",
-			exporter: &OTLPExporterConfig{
-				Type: exporters.BaseOtlpExporterID.String(),
-				ExporterConfig: exporters.ExporterConfig{
+			exporter: &config.ExportConfig{
+				ID: exporters.BaseOtlpExporterID,
+				Exporter: &exporters.ExporterConfig{
 					Endpoint: "https://test-forwarder-endpoint:4138",
 				},
 			},
@@ -55,9 +56,9 @@ func Test_newConfigProvider(t *testing.T) {
 				Organization: "00000000-0000-0000-0000-000000000003",
 				Project:      "00000000-0000-0000-0000-000000000004",
 			},
-			exporter: &OTLPExporterConfig{
-				Type: exporters.BaseOtlpExporterID.String(),
-				ExporterConfig: exporters.ExporterConfig{
+			exporter: &config.ExportConfig{
+				ID: exporters.BaseOtlpExporterID,
+				Exporter: &exporters.ExporterConfig{
 					Endpoint: "https://test-forwarder-endpoint:4138",
 				},
 			},

--- a/internal/otel/config_test.go
+++ b/internal/otel/config_test.go
@@ -24,7 +24,7 @@ import (
 func Test_newConfigProvider(t *testing.T) {
 	testcases := map[string]struct {
 		testfile    string
-		exporter    *config.ExportConfig
+		exporter    *config.ExporterConfig
 		hcpResource *resource.Resource
 	}{
 		"stock": {
@@ -32,7 +32,7 @@ func Test_newConfigProvider(t *testing.T) {
 		},
 		"stock-with-forwarder": {
 			testfile: "stock-with-forwarder.yaml",
-			exporter: &config.ExportConfig{
+			exporter: &config.ExporterConfig{
 				ID: exporters.BaseOtlpExporterID,
 				Exporter: &exporters.ExporterConfig{
 					Endpoint: "https://test-forwarder-endpoint:4138",
@@ -59,7 +59,7 @@ func Test_newConfigProvider(t *testing.T) {
 				Organization: "00000000-0000-0000-0000-000000000003",
 				Project:      "00000000-0000-0000-0000-000000000004",
 			},
-			exporter: &config.ExportConfig{
+			exporter: &config.ExporterConfig{
 				ID: exporters.BaseOtlpExporterID,
 				Exporter: &exporters.ExporterConfig{
 					Endpoint: "https://test-forwarder-endpoint:4138",

--- a/internal/otel/config_test.go
+++ b/internal/otel/config_test.go
@@ -36,6 +36,9 @@ func Test_newConfigProvider(t *testing.T) {
 				ID: exporters.BaseOtlpExporterID,
 				Exporter: &exporters.ExporterConfig{
 					Endpoint: "https://test-forwarder-endpoint:4138",
+					Headers: map[string]string{
+						"authorization": "abc123",
+					},
 				},
 			},
 		},

--- a/internal/otel/providers/external/external.go
+++ b/internal/otel/providers/external/external.go
@@ -14,15 +14,17 @@ import (
 )
 
 type externalProvider struct {
-	otlpHTTPEndpoint string
+	exporterID component.ID
+	exporter   config.Exporter
 }
 
 var _ confmap.Provider = (*externalProvider)(nil)
 
 // NewProvider creates a new static in memory configmap provider.
-func NewProvider(forwarderEndpoint string) confmap.Provider {
+func NewProvider(exporterID component.ID, exporter config.Exporter) confmap.Provider {
 	return &externalProvider{
-		otlpHTTPEndpoint: forwarderEndpoint,
+		exporterID: exporterID,
+		exporter:   exporter,
 	}
 }
 

--- a/internal/otel/providers/external/external.go
+++ b/internal/otel/providers/external/external.go
@@ -14,13 +14,13 @@ import (
 )
 
 type externalProvider struct {
-	exporterConfig *config.ExportConfig
+	exporterConfig *config.ExporterConfig
 }
 
 var _ confmap.Provider = (*externalProvider)(nil)
 
 // NewProvider creates a new static in memory configmap provider.
-func NewProvider(exporterConfig *config.ExportConfig) confmap.Provider {
+func NewProvider(exporterConfig *config.ExporterConfig) confmap.Provider {
 	return &externalProvider{
 		exporterConfig: exporterConfig,
 	}

--- a/internal/otel/providers/external/external.go
+++ b/internal/otel/providers/external/external.go
@@ -45,8 +45,14 @@ func (m *externalProvider) Retrieve(_ context.Context, _ string, _ confmap.Watch
 	}
 
 	// 3. Build external pipeline
-	externalParams := &config.Params{
-		OtlpHTTPEndpoint: m.otlpHTTPEndpoint,
+	externalParams := &config.Params{}
+
+	// see if this is an empty component.ID
+	if m.exporterID.String() != "" {
+		externalParams.ExporterConfig = &config.ExportConfig{
+			ID:       m.exporterID,
+			Exporter: m.exporter,
+		}
 	}
 	externalCfg := config.PipelineConfigBuilder(externalParams)
 	externalID := component.NewID(component.DataTypeMetrics)

--- a/internal/otel/providers/external/external.go
+++ b/internal/otel/providers/external/external.go
@@ -14,17 +14,15 @@ import (
 )
 
 type externalProvider struct {
-	exporterID component.ID
-	exporter   config.Exporter
+	exporterConfig *config.ExportConfig
 }
 
 var _ confmap.Provider = (*externalProvider)(nil)
 
 // NewProvider creates a new static in memory configmap provider.
-func NewProvider(exporterID component.ID, exporter config.Exporter) confmap.Provider {
+func NewProvider(exporterConfig *config.ExportConfig) confmap.Provider {
 	return &externalProvider{
-		exporterID: exporterID,
-		exporter:   exporter,
+		exporterConfig: exporterConfig,
 	}
 }
 
@@ -48,12 +46,10 @@ func (m *externalProvider) Retrieve(_ context.Context, _ string, _ confmap.Watch
 	externalParams := &config.Params{}
 
 	// see if this is an empty component.ID
-	if m.exporterID.String() != "" {
-		externalParams.ExporterConfig = &config.ExportConfig{
-			ID:       m.exporterID,
-			Exporter: m.exporter,
-		}
+	if m.exporterConfig != nil {
+		externalParams.ExporterConfig = m.exporterConfig
 	}
+
 	externalCfg := config.PipelineConfigBuilder(externalParams)
 	externalID := component.NewID(component.DataTypeMetrics)
 	err = c.EnrichWithPipelineCfg(externalCfg, externalParams, externalID)

--- a/internal/otel/providers/external/external_test.go
+++ b/internal/otel/providers/external/external_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func Test_InMem(t *testing.T) {
-	provider := NewProvider(exporters.BaseOtlpExporterID, nil)
+	provider := NewProvider(exporters.BaseOtlpExporterID, &exporters.ExporterConfig{
+		Endpoint: "https://localhost:6060",
+	})
 	retrieved, err := provider.Retrieve(context.Background(), "", nil)
 	test.NoError(t, err)
 

--- a/internal/otel/providers/external/external_test.go
+++ b/internal/otel/providers/external/external_test.go
@@ -30,7 +30,7 @@ func Test_InMem(t *testing.T) {
 	})
 
 	t.Run("with forwarder", func(t *testing.T) {
-		provider := NewProvider(&config.ExportConfig{
+		provider := NewProvider(&config.ExporterConfig{
 			ID: exporters.BaseOtlpExporterID,
 			Exporter: &exporters.ExporterConfig{
 				Endpoint: "https://localhost:6060",

--- a/internal/otel/providers/external/external_test.go
+++ b/internal/otel/providers/external/external_test.go
@@ -10,22 +10,42 @@ import (
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 )
 
 func Test_InMem(t *testing.T) {
-	provider := NewProvider(exporters.BaseOtlpExporterID, &exporters.ExporterConfig{
-		Endpoint: "https://localhost:6060",
-	})
-	retrieved, err := provider.Retrieve(context.Background(), "", nil)
-	test.NoError(t, err)
+	t.Run("no forwarder", func(t *testing.T) {
+		provider := NewProvider(nil)
+		retrieved, err := provider.Retrieve(context.Background(), "", nil)
+		test.NoError(t, err)
 
-	conf, err := retrieved.AsConf()
-	test.NoError(t, err)
-	confMap := conf.ToStringMap()
-	exporters := asMap(t, confMap["exporters"])
-	otlp := asMap(t, exporters["otlphttp"])
-	test.Eq(t, otlp["endpoint"], "https://localhost:6060")
+		conf, err := retrieved.AsConf()
+		test.NoError(t, err)
+		confMap := conf.ToStringMap()
+		exporters := asMap(t, confMap["exporters"])
+		otlp, ok := exporters["otlphttp"]
+		test.False(t, ok)
+		test.Nil(t, otlp)
+	})
+
+	t.Run("with forwarder", func(t *testing.T) {
+		provider := NewProvider(&config.ExportConfig{
+			ID: exporters.BaseOtlpExporterID,
+			Exporter: &exporters.ExporterConfig{
+				Endpoint: "https://localhost:6060",
+			},
+		})
+		retrieved, err := provider.Retrieve(context.Background(), "", nil)
+		test.NoError(t, err)
+
+		conf, err := retrieved.AsConf()
+		test.NoError(t, err)
+		confMap := conf.ToStringMap()
+		exporters := asMap(t, confMap["exporters"])
+		otlp := asMap(t, exporters["otlphttp"])
+		test.Eq(t, otlp["endpoint"], "https://localhost:6060")
+	})
 }
 
 func asMap(t *testing.T, a any) map[string]any {

--- a/internal/otel/providers/external/external_test.go
+++ b/internal/otel/providers/external/external_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
+
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 )
 
 func Test_InMem(t *testing.T) {

--- a/internal/otel/providers/external/external_test.go
+++ b/internal/otel/providers/external/external_test.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )
 
 func Test_InMem(t *testing.T) {
-	provider := NewProvider("https://localhost:6060")
+	provider := NewProvider(exporters.BaseOtlpExporterID, nil)
 	retrieved, err := provider.Retrieve(context.Background(), "", nil)
 	test.NoError(t, err)
 

--- a/internal/otel/providers/hcp/provider.go
+++ b/internal/otel/providers/hcp/provider.go
@@ -102,7 +102,6 @@ func (m *hcpProvider) Retrieve(
 	// forward component.ID and other components are included in the service stanza and are activated by the collector.
 	// An improvement here would be to separate the service stanza creation from the HCP or External generators. This
 	// would allow component configuration to happen separately from the service stanza and removing repeated work.
-
 	externalParams := &config.Params{
 		ExporterConfig: m.exporterConfig,
 	}

--- a/internal/otel/providers/hcp/provider.go
+++ b/internal/otel/providers/hcp/provider.go
@@ -18,7 +18,7 @@ import (
 )
 
 type hcpProvider struct {
-	exporterConfig *config.ExportConfig
+	exporterConfig *config.ExporterConfig
 	client         hcp.TelemetryClient
 	clientID       string
 	clientSecret   string
@@ -32,7 +32,7 @@ var _ confmap.Provider = (*hcpProvider)(nil)
 
 // NewProvider creates a new static in memory configmap provider.
 func NewProvider(
-	exporterConfig *config.ExportConfig,
+	exporterConfig *config.ExporterConfig,
 	client hcp.TelemetryClient,
 	clientID,
 	clientSecret string,

--- a/internal/otel/providers/hcp/provider.go
+++ b/internal/otel/providers/hcp/provider.go
@@ -95,7 +95,14 @@ func (m *hcpProvider) Retrieve(
 		return nil, err
 	}
 
-	// 3. B: Build external pipeline
+	// 3. B: Build external pipeline We need to build this external pipeline because of how otel merges configuration.
+	// It does _not_ perform a deep merge and instead performs an overriding merge at the highest matching level. This
+	// behavior means that the service object will never match between the HCP provider and the External provider
+	// without ensuring that the external generator _also_ executes for HCP. The external generator will ensure that the
+	// forward component.ID and other components are included in the service stanza and are activated by the collector.
+	// An improvement here would be to separate the service stanza creation from the HCP or External generators. This
+	// would allow component configuration to happen separately from the service stanza and removing repeated work.
+
 	externalParams := &config.Params{
 		ExporterConfig: m.exporterConfig,
 	}

--- a/internal/otel/testdata/stock-with-forwarder.yaml
+++ b/internal/otel/testdata/stock-with-forwarder.yaml
@@ -31,6 +31,7 @@ exporters:
     compression: "none"
     headers:
       user-agent: "Go-http-client/1.1"
+      authorization: "abc123"
 
 connectors: {}
 
@@ -41,7 +42,7 @@ service:
     logs:
       encoding: console
       output_paths: stderr
-      error_output_paths: [stderr]  
+      error_output_paths: [stderr]
       initial_fields: {}
     metrics:
       address: localhost:9090


### PR DESCRIPTION
This changeset creates a new block of configuration for the otlphttp exporter allowing the user more configuration options than before. The previous `http_forwarder_endpoint` is now deprecated and warnings are logged when both values are set. The configuration is then translated to an internal type to generate the actual exporter configuration.

Unit testing was performed to ensure that we are still shipping the same otel configuration to the otel server and new configuration options were exercised in the test cases.

A future PR will handle pulling in the otelgrpc exporter