### PR TITLE
Without the exporter interface

### DIFF
--- a/internal/otel/collector.go
+++ b/internal/otel/collector.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
 	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config"
-	"github.com/hashicorp/consul-telemetry-collector/internal/otel/config/helpers/exporters"
 	"github.com/hashicorp/consul-telemetry-collector/internal/version"
 )
 
@@ -32,12 +31,6 @@ type CollectorCfg struct {
 	Client            hcp.TelemetryClient
 	ForwarderEndpoint string
 	ExporterConfig    *config.ExportConfig
-}
-
-// OTLPExporterConfig holds the type and
-type OTLPExporterConfig struct {
-	ExporterConfig exporters.ExporterConfig
-	Type           string
 }
 
 const otelFeatureGate = "telemetry.useOtelForInternalMetrics"

--- a/internal/otel/config/builder.go
+++ b/internal/otel/config/builder.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service/pipelines"
 
 	"github.com/hashicorp/consul-telemetry-collector/internal/hcp"
@@ -28,12 +27,7 @@ type Params struct {
 // ExportConfig holds a dynamic exporter configuration and corresponding component.ID
 type ExportConfig struct {
 	ID       component.ID
-	Exporter Exporter
-}
-
-// Exporter returns the confmap.Conf representation of an open-telemetry-collector exporter
-type Exporter interface {
-	Config() (*confmap.Conf, error)
+	Exporter *exporters.ExporterConfig
 }
 
 // PipelineConfigBuilder defines a basic list of pipeline component IDs for a service.PipelineConfig.

--- a/internal/otel/config/config.go
+++ b/internal/otel/config/config.go
@@ -150,7 +150,7 @@ func buildComponent(id component.ID, p *Params) (any, error) {
 		return extensions.OauthClientCfg(p.ClientID, p.ClientSecret), nil
 	default:
 		if id == p.ExporterConfig.ID {
-			cfg, err := p.ExporterConfig.Exporter.Config()
+			cfg, err := exporters.OtlpExporterCfg(p.ExporterConfig.Exporter)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/otel/config/helpers/exporters/otlp_exporter_test.go
+++ b/internal/otel/config/helpers/exporters/otlp_exporter_test.go
@@ -12,12 +12,10 @@ import (
 )
 
 func Test_OtlpExporter(t *testing.T) {
-	cfg := OtlpExporterCfg("foobar")
-	require.NotNil(t, cfg)
-
-	// Marshall the configuration
-	conf := confmap.New()
-	err := conf.Marshal(cfg)
+	e := &ExporterConfig{
+		Endpoint: "foobar",
+	}
+	conf, err := OtlpExporterCfg(e)
 	require.NoError(t, err)
 
 	// Unmarshall and verify
@@ -25,7 +23,9 @@ func Test_OtlpExporter(t *testing.T) {
 	err = conf.Unmarshal(unmarshalledCfg)
 	require.NoError(t, err)
 
-	require.Equal(t, cfg, unmarshalledCfg)
+	require.Equal(t, e.Endpoint, unmarshalledCfg.Endpoint)
+	require.Equal(t, e.Compression, defaultCompression)
+	require.Equal(t, unmarshalledCfg.Headers["user-agent"], defaultUserAgent)
 }
 
 func Test_OtlpExporterHCP(t *testing.T) {


### PR DESCRIPTION
I suggested something in the PR, and felt like it might be easier to show what I mean by making a small PR on top:

- Removes the `type Exporter interface` interface, instead extend the `OtlpExporterCfg` method to perform the merge. 
- In `config.go`, use the method directly : `cfg, err := exporters.OtlpExporterCfg(p.ExporterConfig.Exporter)`

The above also follows the pattern of what we do for the HCP provider, so it's more consistent, i.e. :
https://github.com/hashicorp/consul-telemetry-collector/blob/8b03bae3d15cc7e4216295eecb7dbed5b1a2eaf6/internal/otel/config/config.go#L143

- Update tests to validates that configuration gets merged as expected

Additional small cleanups:
- Remove the unused `type OTLPExporterConfig struct`